### PR TITLE
Make enum_settings have the same param order as other settings

### DIFF
--- a/msu/systems/mod_settings/enum_setting.nut
+++ b/msu/systems/mod_settings/enum_setting.nut
@@ -3,13 +3,9 @@ this.MSU.Class.EnumSetting <- class extends this.MSU.Class.AbstractSetting
 	Array = null;
 	static Type = "Enum";
 
-	constructor( _id, _array, _value = null, _name = null )
+	constructor( _id, _value, _array, _name = null )
 	{
-		if (_value == null)
-		{
-			_value = _array[0];
-		}
-		else if (_array.find(_value) == null)
+		if (_array.find(_value) == null)
 		{
 			this.logError("Value must be an element in the Array");
 			throw this.Exception.KeyNotFound;


### PR DESCRIPTION
Technically a breaking change, noticed this while working on eimo and it bothered me a lot so I wanna fix it before release. Let me know if you have any issues with it.