### PR TITLE
Add mirror of mod-settings in JS code using MSUConnection

### DIFF
--- a/msu/systems/mod_settings/abstract_setting.nut
+++ b/msu/systems/mod_settings/abstract_setting.nut
@@ -1,13 +1,12 @@
 this.MSU.Class.AbstractSetting <- class extends this.MSU.Class.SettingsElement
 {
-	
 	static Type = "Abstract";
 	Value = null;// Serialized
 	Locked = null; // Serialized
 	LockReason = null; // Serialized
 	Callbacks = null;
 	ParseChange = null; //if it should print change to log for further manipulation
-	
+
 	constructor( _id, _value, _name = null )
 	{
 		base.constructor(_id, _name)
@@ -41,7 +40,7 @@ this.MSU.Class.AbstractSetting <- class extends this.MSU.Class.SettingsElement
 		this.Callbacks.push(_callback);
 	}
 
-	function set( _value )
+	function set( _value, _updateJS = true )
 	{
 		if (this.Locked)
 		{
@@ -50,6 +49,10 @@ this.MSU.Class.AbstractSetting <- class extends this.MSU.Class.SettingsElement
 		}
 
 		this.Value = _value
+		if (_updateJS)
+		{
+			this.MSU.UI.JSConnection.updateSetting(this.PanelID, this.getID(), this.getValue())
+		}
 	}
 
 	function getValue()

--- a/msu/systems/mod_settings/abstract_setting.nut
+++ b/msu/systems/mod_settings/abstract_setting.nut
@@ -51,7 +51,7 @@ this.MSU.Class.AbstractSetting <- class extends this.MSU.Class.SettingsElement
 		this.Value = _value
 		if (_updateJS)
 		{
-			this.MSU.UI.JSConnection.updateSetting(this.getParent().getParent().getID(), this.getID(), this.getValue())
+			this.MSU.UI.JSConnection.updateSetting(this.getPanelID(), this.getID(), this.getValue())
 		}
 	}
 

--- a/msu/systems/mod_settings/abstract_setting.nut
+++ b/msu/systems/mod_settings/abstract_setting.nut
@@ -51,7 +51,7 @@ this.MSU.Class.AbstractSetting <- class extends this.MSU.Class.SettingsElement
 		this.Value = _value
 		if (_updateJS)
 		{
-			this.MSU.UI.JSConnection.updateSetting(this.PanelID, this.getID(), this.getValue())
+			this.MSU.UI.JSConnection.updateSetting(this.getParent().getParent().getID(), this.getID(), this.getValue())
 		}
 	}
 

--- a/msu/systems/mod_settings/load.nut
+++ b/msu/systems/mod_settings/load.nut
@@ -35,12 +35,12 @@ local testSettingsSystem = function()
 			// test1.lock()
 			local test2 = this.MSU.Class.BooleanSetting("TestBool" + j + 1, rand() % 2 == 0);
 			test2.addFlags("NewCampaign", "NewCampaignOnly")
-			local test3 = this.MSU.Class.EnumSetting("TestEnum" + j, ["hi", "hello", "goodbye"], "goodbye");
+			local test3 = this.MSU.Class.EnumSetting("TestEnum" + j, "goodbye", ["hi", "hello", "goodbye"]);
 			test3.lock()
-			local test4 = this.MSU.Class.EnumSetting("TestEnum" + j + 1, ["hi", "hello", "goodbye"]);
+			local test4 = this.MSU.Class.EnumSetting("TestEnum" + j + 1,"hi", ["hi", "hello", "goodbye"]);
 			local divider = this.MSU.Class.SettingsDivider("divider")
 
-			local test5 = this.MSU.Class.EnumSetting("TestEnum" + j + 2, ["hi", "hello", "goodbye"]);
+			local test5 = this.MSU.Class.EnumSetting("TestEnum" + j + 2, "hi", ["hi", "hello", "goodbye"]);
 
 			testPage.add(test);
 			testPage.add(test1);

--- a/msu/systems/mod_settings/mod_settings_system.nut
+++ b/msu/systems/mod_settings/mod_settings_system.nut
@@ -31,6 +31,11 @@ this.MSU.Class.ModSettingsSystem <- class extends this.MSU.Class.System
 		return this.Panels[_id];
 	}
 
+	function getPanels()
+	{
+		return this.Panels;
+	}
+
 	function has( _id )
 	{
 		return _id in this.Panels
@@ -73,9 +78,8 @@ this.MSU.Class.ModSettingsSystem <- class extends this.MSU.Class.System
 					{
 						this.MSU.PersistentDataManager.writeToLog("ModSetting", "MSU",  format("%s;%s", settingID, value.tostring()))
 					}
+					setting.set(value);
 				}
-
-				setting.set(value);
 			}
 		}
 	}
@@ -122,6 +126,16 @@ this.MSU.Class.ModSettingsSystem <- class extends this.MSU.Class.System
 			}
 		}
 		ret.reverse() //No idea why conversion to JS reverses the array, but it does so I am pre-empting this.
+		return ret;
+	}
+
+	function getLogicalData()
+	{
+		local ret = {};
+		foreach (panel in this.getPanels())
+		{
+			ret[panel.getID()] <- panel.getLogicalData();
+		}
 		return ret;
 	}
 

--- a/msu/systems/mod_settings/settings_element.nut
+++ b/msu/systems/mod_settings/settings_element.nut
@@ -5,6 +5,7 @@ this.MSU.Class.SettingsElement <- class
 	static Type = "Element";
 	Flags = null;
 	Description = null;
+	PanelID = null;
 
 	constructor(_id, _name = null)
 	{
@@ -22,6 +23,11 @@ this.MSU.Class.SettingsElement <- class
 	function getType()
 	{
 		return this.Type;
+	}
+
+	function setPanelID( _panelID )
+	{
+		this.PanelID = _panelID;
 	}
 
 	function setDescription( _description )

--- a/msu/systems/mod_settings/settings_element.nut
+++ b/msu/systems/mod_settings/settings_element.nut
@@ -5,7 +5,7 @@ this.MSU.Class.SettingsElement <- class
 	static Type = "Element";
 	Flags = null;
 	Description = null;
-	PanelID = null;
+	Parent = null;
 
 	constructor(_id, _name = null)
 	{
@@ -25,9 +25,14 @@ this.MSU.Class.SettingsElement <- class
 		return this.Type;
 	}
 
-	function setPanelID( _panelID )
+	function setParent( _parent )
 	{
-		this.PanelID = _panelID;
+		this.Parent = _parent;
+	}
+
+	function getParent()
+	{
+		return this.Parent;
 	}
 
 	function setDescription( _description )

--- a/msu/systems/mod_settings/settings_element.nut
+++ b/msu/systems/mod_settings/settings_element.nut
@@ -35,6 +35,11 @@ this.MSU.Class.SettingsElement <- class
 		return this.Parent;
 	}
 
+	function getPanelID()
+	{
+		return this.getParent().getParent().getID();
+	}
+
 	function setDescription( _description )
 	{
 		this.Description = _description;

--- a/msu/systems/mod_settings/settings_page.nut
+++ b/msu/systems/mod_settings/settings_page.nut
@@ -3,6 +3,7 @@ this.MSU.Class.SettingsPage <- class
 	Name = null;
 	ID = null;
 	Settings = null;
+	PanelID = null;
 
 	constructor( _id, _name = null )
 	{
@@ -18,7 +19,17 @@ this.MSU.Class.SettingsPage <- class
 			this.logError("Failed to add element: element needs to be one of the Setting elements inheriting from SettingsElement");
 			throw this.Exception.InvalidType;
 		}
+		_element.setPanelID(this.PanelID)
 		this.Settings[_element.getID()] <- _element;
+	}
+
+	function setPanelID( _panelID )
+	{
+		this.PanelID = _panelID;
+		foreach (setting in this.getSettings())
+		{
+			setting.setPanelID(_panelID);
+		}
 	}
 
 	function getID()

--- a/msu/systems/mod_settings/settings_page.nut
+++ b/msu/systems/mod_settings/settings_page.nut
@@ -33,6 +33,11 @@ this.MSU.Class.SettingsPage <- class
 		return this.Parent;
 	}
 
+	function getPanelID()
+	{
+		return this.getParent().getID();
+	}
+
 	function getID()
 	{
 		return this.ID;

--- a/msu/systems/mod_settings/settings_page.nut
+++ b/msu/systems/mod_settings/settings_page.nut
@@ -3,7 +3,7 @@ this.MSU.Class.SettingsPage <- class
 	Name = null;
 	ID = null;
 	Settings = null;
-	PanelID = null;
+	Parent = null;
 
 	constructor( _id, _name = null )
 	{
@@ -19,17 +19,18 @@ this.MSU.Class.SettingsPage <- class
 			this.logError("Failed to add element: element needs to be one of the Setting elements inheriting from SettingsElement");
 			throw this.Exception.InvalidType;
 		}
-		_element.setPanelID(this.PanelID)
+		_element.setParent(this);
 		this.Settings[_element.getID()] <- _element;
 	}
 
-	function setPanelID( _panelID )
+	function setParent( _parent )
 	{
-		this.PanelID = _panelID;
-		foreach (setting in this.getSettings())
-		{
-			setting.setPanelID(_panelID);
-		}
+		this.Parent = _parent;
+	}
+
+	function getParent()
+	{
+		return this.Parent;
 	}
 
 	function getID()

--- a/msu/systems/mod_settings/settings_panel.nut
+++ b/msu/systems/mod_settings/settings_panel.nut
@@ -22,6 +22,7 @@ this.MSU.Class.SettingsPanel <- class
 		{
 			throw this.Exception.InvalidType;
 		}
+		_page.setPanelID(this.ID)
 		this.Pages[_page.getID()] <- _page;
 	}
 
@@ -29,7 +30,7 @@ this.MSU.Class.SettingsPanel <- class
 	{
 		foreach (page in this.Pages)
 		{
-			if ( page.Settings.Array.find(_settingID) != null)
+			if (page.Settings.Array.find(_settingID) != null)
 			{
 				return page.get(_settingID);
 			}
@@ -70,7 +71,7 @@ this.MSU.Class.SettingsPanel <- class
 		return this.ID;
 	}
 
-	function doSettingsFunction( _function, ... )
+	function callSettingsFunction( _function, ... )
 	{
 		vargv.insert(0, null);
 		foreach (page in this.Pages)
@@ -88,17 +89,17 @@ this.MSU.Class.SettingsPanel <- class
 
 	function flagSerialize()
 	{
-		this.doSettingsFunction("flagSerialize", this.getID());
+		this.callSettingsFunction("flagSerialize", this.getID());
 	}
 
 	function flagDeserialize()
 	{
-		this.doSettingsFunction("flagDeserialize", this.getID());
+		this.callSettingsFunction("flagDeserialize", this.getID());
 	}
 
 	function resetFlags()
 	{
-		this.doSettingsFunction("resetFlags", this.getID());
+		this.callSettingsFunction("resetFlags", this.getID());
 	}
 
 	function getUIData( _flags )
@@ -117,6 +118,22 @@ this.MSU.Class.SettingsPanel <- class
 			}
 		}
 
+		return ret;
+	}
+
+	function getLogicalData()
+	{
+		local ret = {};
+		foreach (page in this.getPages())
+		{
+			foreach (setting in page.getSettings())
+			{
+				if (setting instanceof this.MSU.Class.AbstractSetting)
+				{
+					ret[setting.getID()] <- setting.getValue()
+				}
+			}
+		}
 		return ret;
 	}
 }

--- a/msu/systems/mod_settings/settings_panel.nut
+++ b/msu/systems/mod_settings/settings_panel.nut
@@ -22,7 +22,7 @@ this.MSU.Class.SettingsPanel <- class
 		{
 			throw this.Exception.InvalidType;
 		}
-		_page.setPanelID(this.ID)
+		_page.setParent(this)
 		this.Pages[_page.getID()] <- _page;
 	}
 
@@ -30,7 +30,7 @@ this.MSU.Class.SettingsPanel <- class
 	{
 		foreach (page in this.Pages)
 		{
-			if (page.Settings.Array.find(_settingID) != null)
+			if (page.getSettings().contains(_settingID))
 			{
 				return page.get(_settingID);
 			}

--- a/scripts/mods/msu/msu_connection.nut
+++ b/scripts/mods/msu/msu_connection.nut
@@ -5,10 +5,30 @@ this.msu_connection <- this.inherit("scripts/mods/msu/js_connection", {
 	{
 		this.m.JSHandle = this.UI.connect("MSUConnection", this);
 		this.passKeybinds();
+		this.passSettings();
 	}
 
 	function passKeybinds()
 	{
 		this.m.JSHandle.asyncCall("setCustomKeybinds", this.MSU.CustomKeybinds.CustomBindsJS);
+	}
+
+	function passSettings()
+	{
+		this.m.JSHandle.asyncCall("setSettings", this.MSU.System.ModSettings.getLogicalData())
+	}
+
+	function updateSetting( _modID, _settingID, _value )
+	{
+		this.m.JSHandle.asyncCall("updateSetting", {
+			mod = _modID,
+			setting = _settingID,
+			value = _value
+		});
+	}
+
+	function updateSettingJS( _data )
+	{
+		::getModSetting(_data.mod, _data.setting).set(_data.value, false);
 	}
 });

--- a/ui/mods/msu/msu_connection.js
+++ b/ui/mods/msu/msu_connection.js
@@ -5,6 +5,7 @@ var MSU = {}
 var MSUConnection = function ()
 {
 	MSUBackendConnection.call(this);
+	this.mModSettings = {};
 }
 
 MSUConnection.prototype = Object.create(MSUBackendConnection.prototype)
@@ -20,6 +21,42 @@ MSUConnection.prototype.setCustomKeybinds = function (_keybinds)
 	})
 	MSU.CustomKeybinds.setFromSQ(_keybinds);
 	//test
+}
+
+MSUConnection.prototype.setSettings = function (_settings)
+{
+	this.mModSettings = _settings;
+}
+
+MSUConnection.prototype.updateSetting = function (_setting)
+{
+	this.mModSettings[_setting.mod][_setting.setting] = _setting.value;
+}
+
+var getModSettingValue = function (_modID, _settingID)
+{
+	return Screens["MSUConnection"].mModSettings[_modID][_setting];
+}
+
+var setModSettingValue = function (_modID, _settingID, _value)
+{
+	Screens["MSUConnection"].setModSettingValue(_modID, _settingID, _value);
+}
+
+MSUConnection.prototype.setModSettingValue = function (_modID, _settingID, _value)
+{
+	this.mModSettings[_modID][_settingID] = _value;
+	var out = {
+		mod : _modID,
+		setting : _settingID,
+		value : _value
+	}
+	this.notifyBackendUpdateSetting(out);
+}
+
+MSUConnection.prototype.notifyBackendUpdateSetting = function(_data)
+{
+	SQ.call(this.mSQHandle, "updateSettingJS", _data);
 }
 
 registerScreen("MSUConnection", new MSUConnection());

--- a/ui/mods/msu/ui_screen.js
+++ b/ui/mods/msu/ui_screen.js
@@ -44,7 +44,7 @@ MSUUIScreen.prototype.unbindTooltips = function ()
 
 }
 
-MSUUIScreen.prototype.show = function (_data)
+MSUUIScreen.prototype.show = function ()
 {
 	var self = this;
 	var moveTo = { opacity: 1, right: '10.0rem' };


### PR DESCRIPTION
In order to have a setting update the JS code when it has a new value set, settings elements are now aware of the panelid of the panel they are in. I tried to think of ways around this but the only one I could think of was making settings not be objects and instead do all the computation within panels which imo isn't really an option anymore.

I'm very open to other suggestions though as I'm not really that happy with this solution.