### PR TITLE
feat: add ability to add skill events via MSU based `addEvent` function

### DIFF
--- a/msu/hooks/skills/skill_container.nut
+++ b/msu/hooks/skills/skill_container.nut
@@ -378,4 +378,9 @@
 
 		return ret;
 	}
+
+	foreach (event in ::MSU.Skills.EventsToAdd)
+	{
+		o[event.Name] <- @(...) this.doOnFunction(event.Name, vargv, event.Update, event.AliveOnly);
+	}
 });

--- a/msu/utilities/skills.nut
+++ b/msu/utilities/skills.nut
@@ -1,0 +1,17 @@
+::MSU.Skills <- {
+	EventsToAdd = [],
+
+	function addEvent( _name, _isEmpty = true, _function = null, _update = false, _aliveOnly = false )
+	{
+		this.EventsToAdd.push({
+			Name = _name,
+			Update = _update,
+			AliveOnly = _aliveOnly
+		});
+
+		::mods_hookBaseClass("skills/skill", function(o) {
+			o = o[o.SuperName];
+			o[_name] <- _function == null ? function() {} : _function;
+		});
+	}
+}


### PR DESCRIPTION
The `_isEmpty` argument is there in case we want to implement a system later on where only those events are called which are present in a skill's nut file. In this case, non-empty functions should be always called and, therefore, it is necessary to know if the event is empty or not.