### PR TITLE
Add handling for function members in sortAscending and sortDescending

### DIFF
--- a/msu/utilities/array.nut
+++ b/msu/utilities/array.nut
@@ -33,7 +33,7 @@
 	{
 		if (_member == null)
 		{
-			_array.sort(function(_a, _b) { if (_a < _b) return -1; if (_a > _b) return 1; return 0 });
+			_array.sort(function(_a, _b) { if (_a > _b) return -1; if (_a < _b) return 1; return 0 });
 		}
 		else
 		{

--- a/msu/utilities/array.nut
+++ b/msu/utilities/array.nut
@@ -37,7 +37,14 @@
 		}
 		else
 		{
-			_array.sort(function(_a, _b) { if (_a[_member] > _b[_member]) return -1; if (_a[_member] < _b[_member]) return 1; return 0 });	
+			if (typeof _array[0][_member] == "function")
+			{
+				_array.sort(function(_a, _b) { if (_a[_member]() > _b[_member]()) return -1; if (_a[_member]() < _b[_member]()) return 1; return 0; });
+			}
+			else
+			{
+				_array.sort(function(_a, _b) { if (_a[_member] > _b[_member]) return -1; if (_a[_member] < _b[_member]) return 1; return 0; });	
+			}
 		}
 	}
 
@@ -49,7 +56,14 @@
 		}
 		else
 		{
-			_array.sort(function(_a, _b) { if (_a[_member] > _b[_member]) return 1; if (_a[_member] < _b[_member]) return -1; return 0 });	
+			if (typeof _array[0][_member] == "function")
+			{
+				_array.sort(function(_a, _b) { _a[_member]() <=> _b[_member]() });
+			}
+			else
+			{
+				_array.sort(function(_a, _b) { _a[_member] <=> _b[_member] });
+			}
 		}
 	}
 }


### PR DESCRIPTION
Is this necessary? Having this feature would help for example with cases where you sort based on a function like `getName()`. For example this case in mod_settings_system.nut:
```
function finalize()
{
	this.Locked = true;
	this.Panels.sort(this.sortPanelsByName);
}
	
function sortPanelsByName( _key1, _mod1, _key2, _mod2 )
{
	return _mod1.getName() <=> _mod2.getName();
}
```
could be replaced with:
```
::MSU.Array.sortAscending(this.Panels, "getName");
```
EDIT: Actually no, because `this.Panels` is OrderedMap, not array. So the example above isn't exactly applicable, but you get the idea.