### PR TITLE
Close Issue #14

### DIFF
--- a/msu/hooks/entity/tactical/actor.nut
+++ b/msu/hooks/entity/tactical/actor.nut
@@ -204,25 +204,6 @@
 		return totalArmorMax > 0 ? currentArmor / (totalArmorMax * 1.0) : 0.0;
 	}
 
-	o.getTotalArmorStaminaModifier <- function()
-	{
-		local ret = 0;
-		local bodyArmor = this.getItems().getItemAtSlot(::Const.ItemSlot.Body);
-		local headArmor = this.getItems().getItemAtSlot(::Const.ItemSlot.Head);
-
-		if (bodyArmor != null)
-		{
-			ret += bodyArmor.getStaminaModifier();
-		}
-
-		if (headArmor != null)
-		{
-			ret += headArmor.getStaminaModifier();
-		}
-
-		return ret;
-	}
-
 	o.isEngagedInMelee <- function()
 	{
 		return this.isPlacedOnMap() && this.getTile().hasZoneOfControlOtherThan(this.getAlliedFactions());

--- a/msu/hooks/items/item_container.nut
+++ b/msu/hooks/items/item_container.nut
@@ -39,6 +39,43 @@
 		this.m.Actor.getSkills().update();
 	}
 
+	o.getStaminaModifier <- function( _slots = null )
+	{
+		if (_slots == null)
+		{
+			 _slots = clone ::Const.ItemSlot;
+			 delete _slots.None;
+			 delete _slots.COUNT;
+		}
+		else
+		{
+			if (typeof _slots == "integer") _slots = [_slots];
+		}
+
+		local ret = 0;
+
+		foreach (slot in _slots)
+		{
+			local items = this.getAllItemsAtSlot(slot);
+			foreach (item in items)
+			{
+				// Avoid exceptions for items which don't have getStaminaModifier()
+				// This handles cases such as Quivers in ammo slot which don't have
+				// this function in vanilla but do in mods like Legends
+				try
+				{
+					ret += item.getStaminaModifier();
+				}
+				catch (error)
+				{
+					::MSU.Mod.Debug.printError(error + " -- for item: " + item.getID(), "debug");
+				}
+			}
+		}
+
+		return ret;
+	}
+
 	local onNewRound = o.onNewRound;
 	o.onNewRound = function()
 	{

--- a/msu/hooks/items/item_container.nut
+++ b/msu/hooks/items/item_container.nut
@@ -62,14 +62,7 @@
 				// Avoid exceptions for items which don't have getStaminaModifier()
 				// This handles cases such as Quivers in ammo slot which don't have
 				// this function in vanilla but do in mods like Legends
-				try
-				{
-					ret += item.getStaminaModifier();
-				}
-				catch (error)
-				{
-					::MSU.Mod.Debug.printError(error + " -- for item: " + item.getID(), "debug");
-				}
+				if (::MSU.isIn("getStaminaModifier", item)) ret += item.getStaminaModifier();
 			}
 		}
 


### PR DESCRIPTION
refactor!: remove getTotalArmorStaminaModifier from actor and add a substitute function in item_container

The new function accepts either an array of slots or a single slot. By default it returns the total StaminaModifier of items in all slots. It has built-in handling for items which may not have the getStaminaModifier() function in them.

The rationale behind removing the function from actor and adding to item_container is that StaminaModifier is a purely item property and while perks such as Brawny affect how much stamina the actor loses due to his items, the StaminaModifier of the items remains static. Therefore, keeping this function in the actor is misleading.