### PR TITLE
feat: add MSU.isKindOf function which handles both BB tables and WeakTableRef instances

### DIFF
--- a/msu/utilities/misc.nut
+++ b/msu/utilities/misc.nut
@@ -37,3 +37,23 @@
 			throw ::MSU.Exception.InvalidType(_object);
 	}
 }
+
+::MSU.isKindOf <- function( _object, _className )
+{
+	local obj = _object;
+	if (typeof obj == "instance")
+	{
+		if (obj instanceof ::WeakTableRef)
+		{
+			if (obj.isNull())
+			{
+				::printError("The table inside the WeakTableRef instance is null");
+				throw ::MSU.Exception.KeyNotFound(_className);
+			}
+			obj = obj.get();
+		}
+		else throw ::MSU.Exception.InvalidType(_object);
+	}
+
+	return ::isKindOf(obj, _className);
+}


### PR DESCRIPTION
The vanilla BB isKindOf function only works with BB tables. If you pass a WeakTableRef instance to it, it fails. The MSU version handles both.