### PR TITLE
MSU.Error and refactor code accordingly

### DIFF
--- a/msu/systems/debug/debug_system.nut
+++ b/msu/systems/debug/debug_system.nut
@@ -48,7 +48,8 @@
 	{
 		if (!(_modID in this.Mods))
 		{
-			throw ::MSU.Exception.ModNotRegistered(_modID);
+			::logError(::MSU.Error.ModNotRegistered(_modID));
+			throw ::MSU.Exception.KeyNotFound(_modID);
 		}
 		this.Mods[_modID][_flagID] <- _flagBool;
 		if (_flagBool == true)
@@ -68,6 +69,7 @@
 	{
 		if (!(_modID in this.Mods))
 		{
+			::logError(::MSU.Error.ModNotRegistered(_modID));
 			throw ::MSU.Exception.KeyNotFound(_modID);
 		}
 		if (!(_flagID in this.Mods[_modID]))
@@ -101,7 +103,8 @@
 	{
 		if (!(_modID in this.Mods))
 		{
-			throw ::MSU.Exception.ModNotRegistered(_modID);
+			::logError(::MSU.Error.ModNotRegistered(_modID));
+			throw ::MSU.Exception.KeyNotFound(_modID);
 		}
 
 		if (this.isEnabledForMod(_modID, _flagID))

--- a/msu/systems/empty_mod_addon.nut
+++ b/msu/systems/empty_mod_addon.nut
@@ -2,6 +2,7 @@
 {
 	function _get( _key )
 	{
-		throw ::MSU.Exception.ModNotRegistered();
+		::logError(::MSU.Error.ModNotRegistered(_key));
+		throw ::MSU.Exception.KeyNotFound(_key);
 	}
 }

--- a/msu/systems/keybinds/abstract_keybind.nut
+++ b/msu/systems/keybinds/abstract_keybind.nut
@@ -9,7 +9,11 @@
 	constructor( _modID, _id, _keyCombinations, _name = null )
 	{
 		if (_name == null) _name = _id;
-		if (!(_modID in ::MSU.System.Keybinds.KeybindsByMod)) throw ::MSU.Exception.ModNotRegistered(_modID);
+		if (!(_modID in ::MSU.System.Keybinds.KeybindsByMod))
+		{
+			::logError(::MSU.Error.ModNotRegistered(_modID));
+			throw ::MSU.Exception.KeyNotFound(_modID);
+		}
 		::MSU.requireString(_modID, _id, _keyCombinations, _name);
 
 		this.ModID = _modID;

--- a/msu/systems/registry/registry_system.nut
+++ b/msu/systems/registry/registry_system.nut
@@ -41,14 +41,16 @@
 		local version = split(_version, "+");
 		if (version.len() > 2)
 		{
-			throw ::MSU.Exception.NotSemanticVersion(_version);
+			::logError(::MSU.Error.NotSemanticVersion(_version));
+			throw ::MSU.Exception.InvalidValue(_version);
 		}
 		local metadata = version.len() == 2 ? version[1] : null;
 		version = split(version[0], "-");
 
 		if (version.len() > 2)
 		{
-			throw ::MSU.Exception.NotSemanticVersion(_version);
+			::logError(::MSU.Error.NotSemanticVersion(_version));
+			throw ::MSU.Exception.InvalidValue(_version);
 		}
 
 		local prerelease = version.len() == 2 ? version[1] : null;
@@ -56,7 +58,8 @@
 
 		if (version.len() > 3)
 		{
-			throw ::MSU.Exception.NotSemanticVersion(_version);
+			::logError(::MSU.Error.NotSemanticVersion(_version));
+			throw ::MSU.Exception.InvalidValue(_version);
 		}
 		else if (version.len() < 3)
 		{
@@ -69,14 +72,16 @@
 			{
 				if (!::MSU.String.isInteger(version[i]))
 				{
-					throw ::MSU.Exception.NotSemanticVersion(_version);
+					::logError(::MSU.Error.NotSemanticVersion(_version));
+					throw ::MSU.Exception.InvalidValue(_version);
 				}
 				version[i] = version[i].tointeger();
 			}
 		}
 		catch (error)
 		{
-			throw ::MSU.Exception.NotSemanticVersion(_version);
+			::logError(::MSU.Error.NotSemanticVersion(_version));
+			throw ::MSU.Exception.InvalidValue(_version);
 		}
 
 		local ret = {

--- a/msu/utilities/exceptions.nut
+++ b/msu/utilities/exceptions.nut
@@ -17,3 +17,6 @@ local function getInQuotes( _string )
 	ModNotRegistered = function( _string = "" ) { return format("Register your mod%s with a system before trying to interact with it", getInQuotes(_string)); },
 	InvalidValue = function( _string = "" )  { return format("The value of the variable%s is not acceptable", getInQuotes(_string)); }
 };
+
+::MSU.Error <- {
+};

--- a/msu/utilities/exceptions.nut
+++ b/msu/utilities/exceptions.nut
@@ -12,11 +12,11 @@ local function getInQuotes( _string )
 	NotConnected = function( _string = "" ) { return format("The screen%s does not have a JSHandle (make sure you connect your screens)", getInQuotes(_string)); },
 	AlreadyInState = function( _string = "" ) { return format("Trying to show already visible screen%s or hide an invisible one", getinQuotes(_string)); },
 	InvalidType = function( _string = "" ) { return format("The variable%s is of the wrong type", getInQuotes(_string)); },
-	NotSemanticVersion = function( _string = "" ) { return format("Version%s not formatted according to Semantic Versioning guidelines (see https://semver.org/)", getInQuotes(_string)); },
 	DuplicateKey = function( _string ) { return format("The key%s is already present", getInQuotes(_string)); },
-	ModNotRegistered = function( _string = "" ) { return format("Register your mod%s with a system before trying to interact with it", getInQuotes(_string)); },
 	InvalidValue = function( _string = "" )  { return format("The value of the variable%s is not acceptable", getInQuotes(_string)); }
 };
 
 ::MSU.Error <- {
+	ModNotRegistered = function( _string = "" ) { return format("Register your mod%s with a system before trying to interact with it", getInQuotes(_string)); },
+	NotSemanticVersion = function( _string = "" ) { return format("Given version%s is not formatted according to Semantic Versioning guidelines (see https://semver.org/)", getInQuotes(_string)); }
 };


### PR DESCRIPTION
This accomplishes two things:

1. Keeps true Exceptions separate from info-containing Error messages.
2. Avoids copy pasting strings, as Error messages are contained in MSU.Error and we only need to edit them at one place if we want to change something.

**PR implementation:**
In this PR, it requires two lines of code wherever you wanna throw an error and exception:
```squirrel
::logError(MSU.Error.ModNotRegistered(_key));
throw ::MSU.Exception.KeyNotFound(_key);
```
**Alternative:**
An alternative method could be to implement a `::MSU.exceptionWithError( _exception, _error = null )` function and use it as follows. The name of this function could be shortened to something like `::MSU.exception` or `::MSU.exEr` etc.
```squirrel
throw ::MSU.exceptionWithError(::MSU.Exception.KeyNotFound(_key), ::MSU.Error.ModNotRegistered(_key));
```
Let me know what you guys prefer and, if you prefer the alternative, what name you would like for the function.