### PR TITLE
Utility functions for Array/Table serialization

### DIFF
--- a/msu/systems/serialization/serialization_mod_addon.nut
+++ b/msu/systems/serialization/serialization_mod_addon.nut
@@ -5,4 +5,14 @@
 		local savedVersion = _metaData.getString(this.Mod.getID() + "Version");
 		return savedVersion != "" && ::MSU.System.Registry.compareVersionStrings(savedVersion, _version) > -1;
 	}
+
+	function serializeObject( _object, _out )
+	{
+		::MSU.System.Serialization.serializeObject(_object, _out);
+	}
+
+	function deserializeObject( _in )
+	{
+		::MSU.System.Serialization.deserializeObject(_in);
+	}
 }

--- a/msu/systems/serialization/serialization_system.nut
+++ b/msu/systems/serialization/serialization_system.nut
@@ -1,6 +1,14 @@
 ::MSU.Class.SerializationSystem <- class extends ::MSU.Class.System
 {
 	Mods = null;
+	static DataType = {
+		Integer = 0,
+		Float = 1,
+		Boolean = 2,
+		String = 3,
+		Array = 4,
+		Table = 5
+	};
 
 	constructor()
 	{
@@ -13,5 +21,117 @@
 		base.registerMod(_mod);
 		this.Mods.push(_mod);
 		_mod.Serialization = ::MSU.Class.SerializationModAddon(_mod);
+	}
+
+	function serializeObject( _object, _out )
+	{
+		::MSU.requireOneOfType(["array", "table"], _object);
+
+		local type = typeof _object;
+		local isTable = type == "table";
+
+		if (isTable) _out.writeU8(this.DataType.Table);
+		else _out.writeU8(this.DataType.Array);
+
+		_out.writeU32(_object.len());
+
+		foreach (key, element in _object)
+		{
+			if (isTable) _out.writeString(key);
+			local dataType = typeof element;
+
+			switch (dataType)
+			{
+				case "integer":
+					_out.writeU8(this.DataType.Integer);
+					if (element < 0)
+					{
+						_out.writeBool(true);
+						_out.writeI32(element);
+					}
+					else
+					{
+						_out.writeBool(false);
+						_out.writeU32(element);
+					}
+					break;
+
+				case "float":
+					_out.writeU8(this.DataType.Float);
+					_out.writeF32(element);
+					break;
+
+				case "boolean":
+					_out.writeU8(this.DataType.Boolean);
+					_out.writeBool(element);
+					break;
+
+				case "string":
+					_out.writeU8(this.DataType.String);
+					_out.writeString(element);
+					break;
+
+				case "array":
+					_out.writeU8(this.DataType.Array);
+					::MSU.serializeObject(element, _out);
+					break;
+
+				case "table":
+					_out.writeU8(this.DataType.Table);
+					::MSU.serializeObject(element, _out);
+					break;
+
+				default:
+					throw ::MSU.Exception.InvalidType(element);
+			}
+		}
+	}
+
+	function deserializeObject( _in )
+	{
+		local type = _in.readU8();
+		local isTable = type == this.DataType.Table;
+		local size = _in.readU32();
+
+		local ret = isTable ? {} : array(size, null);
+
+		for (local i = 0; i < size; i++)
+		{
+			local key = isTable ? _in.readString() : null;
+			local dataType = _in.readU8();
+			local val;
+
+			switch (dataType)
+			{
+				case this.DataType.Integer:
+					val = _in.readBool() ? _in.readI32() : _in.readU32();
+					break;
+
+				case this.DataType.Float:
+					val = _in.readF32();
+					break;
+
+				case this.DataType.Boolean:
+					val = _in.readBool();
+					break;
+
+				case this.DataType.String:
+					val = _in.readString();
+					break;
+
+				case this.DataType.Array:
+				case this.DataType.Table:
+					val = ::MSU.deserializeObject(_in);
+					break;
+
+				default:
+					throw ::MSU.Exception.InvalidType(dataType);
+			}
+
+			if (isTable) ret[key] <- val;
+			else ret[i] = val;
+		}
+
+		return ret;
 	}
 }


### PR DESCRIPTION
See the code block below for explanation of the use case. If you guys prefer, **we can limit the serialization to only value types** i.e. integer, boolean, string for now until we are confident we wanna add the table/array stuff (because that can lead to issues if it is an array containing BB classes for example). If we implement this, we can simplify the (de)serialize functions of WeightedContainer to use these utility functions. In cases where the **array/table contains mixed value types**, these functions make life even easier. For example **see PR #81** where I have implemented a serialization system for OrderedMap using these utility functions.
```squirrel
function onSerialize( _out )
{
	_out.writeU32(this.Array.len());
	foreach (item in this.Array)
	{
		_out.writeU32(item); // if it is integer
		 // otherwise use the appropraite writeBool, writeString etc.
	}
}

function onDeserialize( _in )
{
	this.Array = array(_in.readU32(), null);
	for (local i = 0; i < size; i++)
	{
		this.Array[i] = _in.readU32(); // or the appropriate readBool, readString etc.
	}
}

// Instead of the above, with these utility functions you would do:

function onSerialize( _out )
{
	::MSU.serializeObject(this.Array, _out);
}

function onDeserialize( _in )
{
	this.Array = ::MSU.deserializeObject(_in);
}
```