### PR TITLE
Weighted container refactor

### DIFF
--- a/msu/classes/weighted_container.nut
+++ b/msu/classes/weighted_container.nut
@@ -157,6 +157,23 @@
 		this.Array.clear();
 	}
 
+	function top()
+	{
+		local weight = 0;
+		local ret;
+
+		foreach (pair in this.Array)
+		{
+			if (pair[0] > weight)
+			{
+				weight = pair[0];
+				ret = pair[1];
+			}
+		}
+
+		return ret;
+	}
+
 	function roll()
 	{
 		local roll = ::Math.rand(1, this.Total);

--- a/msu/classes/weighted_container.nut
+++ b/msu/classes/weighted_container.nut
@@ -118,10 +118,12 @@
 
 	function apply( _function )
 	{
+		// _function (_item, _weight)
+
 		foreach (i, pair in this.Array)
 		{
 			this.ApplyIdx = i;
-			_function(pair[1]);
+			_function(pair[1], pair[0]);
 		}
 
 		this.ApplyIdx = null;
@@ -129,16 +131,20 @@
 
 	function map( _function )
 	{
+		// _function (_item, _weight)
+
 		return ::MSU.Class.OrderedMap(clone this.Array).apply(_function);
 	}
 
 	function filter( _function )
 	{
+		// _function (_item, _weight)
+
 		local ret = ::MSU.Class.OrderedMap();
 		foreach (i, pair in this.Array)
 		{
 			this.ApplyIdx = i;
-			if (_function(pair[1])) ret.add(pair[1], pair[0]);
+			if (_function(pair[1], pair[0])) ret.add(pair[1], pair[0]);
 		}
 		this.ApplyIdx = null;
 		return ret;

--- a/msu/classes/weighted_container.nut
+++ b/msu/classes/weighted_container.nut
@@ -134,14 +134,14 @@
 	{
 		// _function (_item, _weight)
 
-		return ::MSU.Class.OrderedMap(clone this.Array).apply(_function);
+		return ::MSU.Class.WeightedContainer(clone this.Array).apply(_function);
 	}
 
 	function filter( _function )
 	{
 		// _function (_item, _weight)
 
-		local ret = ::MSU.Class.OrderedMap();
+		local ret = ::MSU.Class.WeightedContainer();
 		foreach (i, pair in this.Array)
 		{
 			this.ApplyIdx = i;
@@ -182,7 +182,7 @@
 
 	function _cloned()
 	{
-		return ::MSU.Class.OrderedMap(clone this.Array);
+		return ::MSU.Class.WeightedContainer(clone this.Array);
 	}
 
 	function len()

--- a/msu/classes/weighted_container.nut
+++ b/msu/classes/weighted_container.nut
@@ -12,9 +12,15 @@
 		this.addArray(_array);
 	}
 
-	function toArray()
+	function toArray( _itemsOnly = true )
 	{
-		return this.Array;
+		local ret = array(this.Array.len(), null);
+		foreach (i, pair in this.Array)
+		{
+			if (_itemsOnly) ret[i] = pair[1];
+			else ret[i] = [pair[0], pair[1]];
+		}
+		return ret;
 	}
 
 	function addArray( _array )

--- a/msu/classes/weighted_container.nut
+++ b/msu/classes/weighted_container.nut
@@ -151,6 +151,12 @@
 		return ret;
 	}
 
+	function clear()
+	{
+		this.Total = 0;
+		this.Array.clear();
+	}
+
 	function roll()
 	{
 		local roll = ::Math.rand(1, this.Total);

--- a/msu/classes/weighted_container.nut
+++ b/msu/classes/weighted_container.nut
@@ -223,62 +223,12 @@
 	function onSerialize( _out )
 	{
 		_out.writeU32(this.Total);
-		_out.writeU32(this.len());
-		foreach (pair in this.Array)
-		{
-			_out.writeU16(pair[0]);
-			switch (typeof pair[1])
-			{
-				case "integer":
-					_out.writeString("integer");
-					_out.writeI32(pair[1]);
-					break;
-
-				case "string":
-					_out.writeString("string");
-					_out.writeString(pair[1]);
-					break;
-
-				case "boolean":
-					_out.writeString("boolean");
-					_out.writeBool(pair[1]);
-					break;
-
-				default:
-					throw ::MSU.Exception.InvalidType(pair[1]);
-			}
-		}
+		::MSU.System.Serialization.serializeObject(this.Array, _out);
 	}
 
 	function onDeserialize( _in )
 	{
 		this.Total = _in.readU32();
-		local size = _in.readU32();
-		for (local i = 0; i < size; ++i)
-		{
-			local weight = _in.readU16();
-			local val;
-			local type = _in.readString();
-			switch (type)
-			{
-				case "integer":
-					val = _in.readI32();
-					break;
-
-				case "string":
-					val = _in.readString();
-					break;
-
-				case "boolean":
-					val = _in.readBool();
-					break;
-
-				default:
-					::logError("The WeightedContainer contents were not (de)serialized properly");
-					throw ::MSU.Exception.InvalidType(type);
-			}
-
-			this.Array.push([weight, val]);
-		}
+		this.Array = ::MSU.System.Serialization.deserializeObject(_in);
 	}
 }

--- a/msu/classes/weighted_container.nut
+++ b/msu/classes/weighted_container.nut
@@ -84,11 +84,6 @@
 
 	function getWeight( _item )
 	{
-		if (this.ApplyIdx != null && this.Array[this.ApplyIdx][1] == _item)
-		{
-			return this.Array[this.ApplyIdx][0];
-		}
-
 		foreach (pair in this.Array)
 		{
 			if (pair[1] == _item) return pair[0];

--- a/msu/classes/weighted_container.nut
+++ b/msu/classes/weighted_container.nut
@@ -134,7 +134,14 @@
 	{
 		// _function (_item, _weight)
 
-		return ::MSU.Class.WeightedContainer(clone this.Array).apply(_function);
+		local ret = ::MSU.Class.WeightedContainer();
+		foreach (i, pair in this.Array)
+		{
+			this.ApplyIdx = i;
+			ret.add(_function(pair[1], pair[0]));
+		}
+		this.ApplyIdx = null;
+		return ret;
 	}
 
 	function filter( _function )


### PR DESCRIPTION
As explained in PR #81, shouldn't the `map` function look like this?
```squirrel
function map( _function )
{
	// _function (_item, _weight)

	local ret = ::MSU.Class.WeightedContainer();
	foreach (pair in this.Array)
	{
		ret.add(_function(pair[1], pair[0]));
	}
	return ret;
}
```
instead of the current:
```squirrel
function map( _function )
{
	// _function (_item, _weight)

	return ::MSU.Class.WeightedContainer(clone this.Array).apply(_function);
}
```