### PR TITLE
Ordered map tweaks

### DIFF
--- a/msu/classes/ordered_map.nut
+++ b/msu/classes/ordered_map.nut
@@ -117,8 +117,11 @@
 	{
 		// _function (_key, _val, _idx)
 
-		local ret = this.filter(@(key, val) return true);
-		ret.apply(_function);
+		local ret = ::MSU.Class.OrderedMap();
+		foreach (i, key in this.Array)
+		{
+			ret[key] <- _function(key, this.Table[key], i);
+		}
 		return ret;
 	}
 

--- a/msu/classes/ordered_map.nut
+++ b/msu/classes/ordered_map.nut
@@ -40,6 +40,14 @@
 		return _prev == this.Array.len() ? null : this.Array[_prev];
 	}
 
+	function _cloned()
+	{
+		local ret = ::MSU.Class.OrderedMap();
+		ret.Array = clone this.Array;
+		ret.Table = clone this.Table;
+		return ret;
+	}
+
 	function sort( _function )
 	{
 		for (local i = 1; i < this.Array.len(); ++i)

--- a/msu/classes/ordered_map.nut
+++ b/msu/classes/ordered_map.nut
@@ -81,4 +81,17 @@
 	{
 		return _key in this.Table;
 	}
+
+	function filter( _function )
+	{
+		// _function (_key, _val)
+
+		local ret = ::MSU.Class.OrderedMap();
+		foreach (key in this.Array)
+		{
+			local val = this.Table[key];
+			if (_function(key, val)) ret[key] <- val;
+		}
+		return ret;
+	}
 }

--- a/msu/classes/ordered_map.nut
+++ b/msu/classes/ordered_map.nut
@@ -104,4 +104,13 @@
 		}
 		return ret;
 	}
+
+	function map( _function )
+	{
+		// _function (_key, _val, _idx)
+
+		local ret = this.filter(@(key, val) return true);
+		ret.apply(_function);
+		return ret;
+	}
 }

--- a/msu/classes/ordered_map.nut
+++ b/msu/classes/ordered_map.nut
@@ -128,4 +128,16 @@
 	{
 		return clone this.Array;
 	}
+
+	function onSerialize( _out )
+	{
+		::MSU.System.Serialization.serializeObject(this.Array, _out);
+		::MSU.System.Serialization.serializeObject(this.Table, _out);
+	}
+
+	function onDeserialize( _in )
+	{
+		this.Array = ::MSU.System.Serialization.deserializeObject(_in);
+		this.Table = ::MSU.System.Serialization.deserializeObject(_in);
+	}
 }

--- a/msu/classes/ordered_map.nut
+++ b/msu/classes/ordered_map.nut
@@ -82,6 +82,16 @@
 		return _key in this.Table;
 	}
 
+	function apply( _function )
+	{
+		// _function (_key, _val, _idx)
+
+		foreach (i, key in this.Array)
+		{
+			_function(key, this.Table[key], i);
+		}
+	}
+
 	function filter( _function )
 	{
 		// _function (_key, _val)

--- a/msu/classes/ordered_map.nut
+++ b/msu/classes/ordered_map.nut
@@ -113,4 +113,19 @@
 		ret.apply(_function);
 		return ret;
 	}
+
+	function values()
+	{
+		local ret = array(this.Array.len(), null);
+		foreach (i, key in this.Array)
+		{
+			ret[i] = this.Table[key];
+		}
+		return ret;
+	}
+
+	function keys()
+	{
+		return clone this.Array;
+	}
 }


### PR DESCRIPTION
My main question is about the `map` function. Looking at the description of the `map` function in squirrel documentation it says:
> This method applies the supplied function to every item in the target array, one by one. The results are placed in a new array created by map() and returned by it. The new array will be the same size as the target array.
Contrast map() with [apply()](https://developer.electricimp.com/squirrel/array/apply) which changes the array’s items in situ.
The passed function must include a single parameter into which each item in the target array is passed. It is the function’s job to make sure the array values passed are appropriate to the changes it will make, if any.

and

> Creates a new array of the same size. For each element in the original array invokes the function ‘func’ and assigns the return value of the function to the corresponding element of the newly created array. Provided func can accept up to 3 arguments: array item value (required), array item index (optional), reference to array itself (optional).

So basically it applies the _function to the elements of the current array and adds the RESULT i.e. return value of that function to the new array. We are not doing this, we are instead adding the elements and then applying the function on them. This is not the same.

So what should we do? (PS: The same question applies to the map function of the WeightedContainer).

**Second question**
How can I allow the passed _function to have 1 required and up to 2 additional optional arguments? How do I handle that e.g. in the `apply` function?